### PR TITLE
Fix default argument

### DIFF
--- a/flirpy/camera/tau.py
+++ b/flirpy/camera/tau.py
@@ -279,7 +279,9 @@ class Tau:
     def enable_tlinear(self):
         pass
     
-    def _send_packet(self, command, argument=[]):
+    def _send_packet(self, command, argument=None):
+        if argument is None:
+            argument = []
 
         # Refer to Tau 2 Software IDD
         # Packet Protocol (Table 3.2)


### PR DESCRIPTION
A mutable like list or dictionary should not be used as a default value to an argument. Python’s default arguments are evaluated once when the function is defined. Using a mutable default argument and mutating it will mutate that object for all future calls to the function as well.