### PR TITLE
Update seq class name

### DIFF
--- a/scripts/split_seqs
+++ b/scripts/split_seqs
@@ -10,7 +10,7 @@ import natsort
 import cv2
 import shutil
 from tqdm import tqdm
-import time
+
 
 def add_bool_arg(parser, name, help_string="", default=False):
     # https://stackoverflow.com/a/31347222
@@ -18,6 +18,7 @@ def add_bool_arg(parser, name, help_string="", default=False):
     group.add_argument('--' + name, dest=name, help=help_string, action='store_true')
     group.add_argument('--no_' + name, dest=name, help=help_string, action='store_false')
     parser.set_defaults(**{name:default})
+
 
 def recursive_copy(src, dst):
 
@@ -37,6 +38,7 @@ def recursive_copy(src, dst):
     
     return
 
+
 def recursive_move(src, dst):
     # https://stackoverflow.com/a/7420617/395457
 
@@ -54,6 +56,7 @@ def recursive_move(src, dst):
                     continue
                 os.remove(dst_file)
             shutil.move(src_file, dst_dir)
+
 
 if __name__ == "__main__":
     
@@ -97,10 +100,8 @@ if __name__ == "__main__":
     for f in files:
         logger.info("Loading: {}".format(f))
     
-    splitter = flirpy.io.seq.splitter(output_folder,
-                    preview_format=args.preview_format,
-                    width=args.width,
-                    height=args.height)
+    splitter = flirpy.io.seq.Splitter(output_folder,
+                    preview_format=args.preview_format)
     splitter.split_filetypes = args.split_filetypes
     splitter.export_meta = args.export_meta
     splitter.export_tiff = args.export_tiff


### PR DESCRIPTION
I was trying to convert a SEQ file to TIFF, and I had the following error:
```
INFO:__main__:Loading: cDdG_1.0b_0001.SEQ
Traceback (most recent call last):
  File "/<dir>/flirpy/scripts/split_seqs", line 100, in <module>
    splitter = flirpy.io.seq.splitter(output_folder,
AttributeError: module 'flirpy.io.seq' has no attribute 'splitter'
```

I did the following:
- run `autopep8` over the file
- update `flirpy.io.seq.Splitter` name (was in lower case)
- remove width and height options for splitter

Now I'm getting the following error
```
Traceback (most recent call last):
  File "<dir>/split_seqs", line 178, in <module>
    folders = splitter.process(files)
  File "/<dir>/flirpy/io/seq.py", line 148, in process
    self.exiftool.write_meta(filemask)
  File "/<dir>/flirpy/util/exiftool.py", line 75, in write_meta
    res = subprocess.call(cmd, cwd=cwd, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
  File "/<dir>/lib/python3.8/subprocess.py", line 340, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/<dir>/python3.8/subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/<dir>/python3.8/subprocess.py", line 1702, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/<dir>/cDdG_1.0b_0001/raw'
```