### PR TITLE
Add gain mode methods to Boson and fix find video device on Mac OS

### DIFF
--- a/flirpy/camera/boson.py
+++ b/flirpy/camera/boson.py
@@ -154,7 +154,7 @@ class Boson(Core):
             device_id = 0
 
             for device in devices:
-                if device.contains("VendorID_2507") and device.contains("ProductID_16391"):
+                if "VendorID_2507" in device and "ProductID_16391" in device:
                     return device_id
             
         else:

--- a/flirpy/camera/boson.py
+++ b/flirpy/camera/boson.py
@@ -704,6 +704,45 @@ class Boson(Core):
 
         return res
 
+    def set_gain_mode(self, gain_mode):
+        """
+        Set the gain mode
+
+        FLR_BOSON_HIGH_GAIN = 0
+        FLR_BOSON_LOW_GAIN = 1
+        FLR_BOSON_AUTO_GAIN = 2
+        FLR_BOSON_DUAL_GAIN = 3
+        FLR_BOSON_MANUAL_GAIN = 4
+        FLR_BOSON_GAINMODE_END = 5
+        """
+
+        function_id = 0x00050014
+        command = struct.pack(">I", int(gain_mode))
+
+        self._send_packet(function_id, data=command)
+    
+    def get_gain_mode(self):
+        """
+        Set the gain mode
+
+        FLR_BOSON_HIGH_GAIN = 0
+        FLR_BOSON_LOW_GAIN = 1
+        FLR_BOSON_AUTO_GAIN = 2
+        FLR_BOSON_DUAL_GAIN = 3
+        FLR_BOSON_MANUAL_GAIN = 4
+        FLR_BOSON_GAINMODE_END = 5
+        """
+
+        function_id = 0x00050015
+
+        res = self._send_packet(function_id)
+        res = self._decode_packet(res, receive_size=4)
+
+        if res is not None and len(res) == 4:
+            res = struct.unpack(">I", res)[0]
+
+        return res
+
     def _decode_packet(self, data, receive_size=0):
         """
         Decodes a data packet from the camera.


### PR DESCRIPTION
- When attempting to run `camera.grab()` on Mac OS 12.2.1, the error `AttributeError: 'str' object has no attribute 'contains'` was thrown. The `contains` method was replaced with `in`.
- Added `set_gain_mode` and `get_gain_mode` methods to Boson class for updating the camera's temperature compensation
