### PR TITLE
Logging Tweaks

### DIFF
--- a/scripts/split_seqs
+++ b/scripts/split_seqs
@@ -87,7 +87,10 @@ if __name__ == "__main__":
         numeric_level = getattr(logging, args.verbosity.upper(), None)
         if not isinstance(numeric_level, int):
             raise ValueError('Invalid log level: %s' % args.verbosity)
-        logger.setLevel(loglevel)
+        if logger.handlers():
+            logger.setLevel(loglevel)
+        else:
+            logging.basicConfig(level=loglevel)
     
     output_folder = os.path.abspath(args.output)
     input_mask = args.input

--- a/scripts/split_seqs
+++ b/scripts/split_seqs
@@ -87,7 +87,7 @@ if __name__ == "__main__":
         numeric_level = getattr(logging, args.verbosity.upper(), None)
         if not isinstance(numeric_level, int):
             raise ValueError('Invalid log level: %s' % args.verbosity)
-        logging.basicConfig(level=numeric_level)
+        logger.setLevel(loglevel)
     
     output_folder = os.path.abspath(args.output)
     input_mask = args.input

--- a/src/flirpy/camera/boson.py
+++ b/src/flirpy/camera/boson.py
@@ -319,7 +319,10 @@ class Boson(Core):
         self.conn = None
 
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(loglevel)
+        if self.logger.handlers():
+            self.logger.setLevel(loglevel)
+        else:
+            logging.basicConfig(level=loglevel)
 
         if port is None:
             port = self.find_serial_device()

--- a/src/flirpy/camera/boson.py
+++ b/src/flirpy/camera/boson.py
@@ -318,8 +318,8 @@ class Boson(Core):
         self.cap = None
         self.conn = None
 
-        logging.basicConfig(level=loglevel)
         self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(loglevel)
 
         if port is None:
             port = self.find_serial_device()

--- a/src/flirpy/camera/lepton.py
+++ b/src/flirpy/camera/lepton.py
@@ -17,7 +17,10 @@ class Lepton(Core):
         self.conn = None
 
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(loglevel)
+        if self.logger.handlers():
+            self.logger.setLevel(loglevel)
+        else:
+            logging.basicConfig(level=loglevel)
 
     @classmethod
     def find_video_device(self):

--- a/src/flirpy/camera/lepton.py
+++ b/src/flirpy/camera/lepton.py
@@ -16,8 +16,8 @@ class Lepton(Core):
         self.cap = None
         self.conn = None
 
-        logging.basicConfig(level=loglevel)
         self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(loglevel)
 
     @classmethod
     def find_video_device(self):


### PR DESCRIPTION
This PR is to fix what i think is an unintended bug for logging. In using flirpy in my code, I noticed that my logs were full of INFO level entries from flirpy despite the default logging level being WARNING. The reason for this is that in my code, I had already run `logging.basicConfig()` and specified a logging level of INFO. `logging.basicConfig()` doesn't do anything if the logging object already has handlers. So, the log level setting for flirpy was being ignored. This PR makes it so that the `setLevel` method is used when the logger already has handlers from `basicConfig` being run. Otherwise, `basicConfig` is run. 